### PR TITLE
ser: Do not transform strings to include single quotes

### DIFF
--- a/tests/test_serde.rs
+++ b/tests/test_serde.rs
@@ -293,30 +293,6 @@ fn test_multiline_string() {
 }
 
 #[test]
-fn test_strings_needing_quote() {
-    #[derive(Serialize, Deserialize, PartialEq, Debug)]
-    struct Struct {
-        boolean: String,
-        integer: String,
-        void: String,
-        leading_zeros: String,
-    }
-    let thing = Struct {
-        boolean: "true".to_owned(),
-        integer: "1".to_owned(),
-        void: "null".to_owned(),
-        leading_zeros: "007".to_owned(),
-    };
-    let yaml = indoc! {"
-        boolean: 'true'
-        integer: '1'
-        void: 'null'
-        leading_zeros: '007'
-    "};
-    test_serde(&thing, yaml);
-}
-
-#[test]
 fn test_nested_vec() {
     let thing = vec![vec![1, 2, 3], vec![4, 5, 6]];
     let yaml = indoc! {"


### PR DESCRIPTION
This change drops the special logic in serialization to add single quotes to certain strings passed into `serialize_str`. Let's leave this up to the user to determine if they want to add special quotes. This gets rid of the problem I was seeing with `serialize_str` of a hex value which was being emitted as '0x1234' instead of 0x1234.

Ideally, I would like to have a way to perform serialize_hex directly instead of having to use the serialize_str function. However, I haven't been able to figure out how to implement a custom serialize function which is not supported by any serde trait. So, pushing this change as a workaround for now.